### PR TITLE
Generalize reduce

### DIFF
--- a/reduce.go
+++ b/reduce.go
@@ -25,9 +25,6 @@ func Reduce(slice, pairFunction, zero interface{}) interface{} {
 		panic("reduce: not slice")
 	}
 	n := in.Len()
-	if n == 0 {
-		return zero
-	}
 	elemType := in.Type().Elem()
 	resType := zeroValue.Type()
 	fn := reflect.ValueOf(pairFunction)
@@ -35,13 +32,10 @@ func Reduce(slice, pairFunction, zero interface{}) interface{} {
 		str := elemType.String()
 		panic("apply: function must be of type func(" + str + ", " + str + ") " + str)
 	}
-	// Do the first two by hand to prime the pump.
-	var ins [2]reflect.Value
-	ins[0] = zeroValue
-	ins[1] = in.Index(0)
-	out := fn.Call(ins[:])[0]
-	// Run from index 1 to the end.
-	for i := 1; i < n; i++ {
+	out := zeroValue
+	// Run from index 0 to the end
+	for i := 0; i < n; i++ {
+		var ins [2]reflect.Value
 		ins[0] = out
 		ins[1] = in.Index(i)
 		out = fn.Call(ins[:])[0]

--- a/reduce.go
+++ b/reduce.go
@@ -20,29 +20,28 @@ import (
 //	factorial := Reduce(a, multiply, 1).(int)
 func Reduce(slice, pairFunction, zero interface{}) interface{} {
 	in := reflect.ValueOf(slice)
+	zeroValue := reflect.ValueOf(zero)
 	if in.Kind() != reflect.Slice {
 		panic("reduce: not slice")
 	}
 	n := in.Len()
-	switch n {
-	case 0:
+	if n == 0 {
 		return zero
-	case 1:
-		return in.Index(0)
 	}
 	elemType := in.Type().Elem()
+	resType := zeroValue.Type()
 	fn := reflect.ValueOf(pairFunction)
-	if !goodFunc(fn, elemType, elemType, elemType) {
+	if !goodFunc(fn, resType, elemType, resType) {
 		str := elemType.String()
 		panic("apply: function must be of type func(" + str + ", " + str + ") " + str)
 	}
 	// Do the first two by hand to prime the pump.
 	var ins [2]reflect.Value
-	ins[0] = in.Index(0)
-	ins[1] = in.Index(1)
+	ins[0] = zeroValue
+	ins[1] = in.Index(0)
 	out := fn.Call(ins[:])[0]
-	// Run from index 2 to the end.
-	for i := 2; i < n; i++ {
+	// Run from index 1 to the end.
+	for i := 1; i < n; i++ {
 		ins[0] = out
 		ins[1] = in.Index(i)
 		out = fn.Call(ins[:])[0]

--- a/reduce_test.go
+++ b/reduce_test.go
@@ -28,6 +28,22 @@ func TestReduceMul(t *testing.T) {
 	}
 }
 
+func TestReduceMul2(t *testing.T) {
+	a := make([]int, 10)
+	for i := range a {
+		a[i] = i + 1
+	}
+	// Compute 10!
+	out := Reduce(a, mul, 2).(int)
+	expect := 2
+	for i := range a {
+		expect *= a[i]
+	}
+	if expect != out {
+		t.Fatalf("expected %d got %d", expect, out)
+	}
+}
+
 func k(x1, x2 *int) *int {
 	return x1
 }

--- a/reduce_test.go
+++ b/reduce_test.go
@@ -12,7 +12,7 @@ func mul(a, b int) int {
 	return a * b
 }
 
-func TestReduce(t *testing.T) {
+func TestReduceMul(t *testing.T) {
 	a := make([]int, 10)
 	for i := range a {
 		a[i] = i + 1
@@ -25,5 +25,57 @@ func TestReduce(t *testing.T) {
 	}
 	if expect != out {
 		t.Fatalf("expected %d got %d", expect, out)
+	}
+}
+
+func k(x1, x2 *int) *int {
+	return x1
+}
+
+func TestReduceNil(t *testing.T) {
+	a := make([]*int, 10)
+	for i := range a {
+		a[i] = nil
+	}
+	var zero *int = nil
+	// Compute nil!
+	out := Reduce(a, k, zero).(*int)
+	expect := zero
+	if expect != out {
+		t.Fatalf("expected %p got %p", expect, out)
+	}
+}
+
+type IntElement struct {
+	Value int
+	Next *IntElement
+}
+
+type IntList *IntElement
+
+func IntListEquals(l1, l2 IntList) bool {
+	for ;l1 != nil && l2 != nil; l1, l2 = l1.Next, l2.Next {
+		if l1.Value != l2.Value {
+			return false
+		}
+	}
+	return true
+}
+
+func rCons(is IntList, i int) IntList {
+	return &IntElement{i, is}
+}
+
+var list4321 = rCons(rCons(rCons(rCons(nil, 1), 2), 3), 4)
+
+func TestReduceIntList(t *testing.T) {
+	a := make([]int, 4)
+	for i := range a {
+		a[i] = i + 1
+	}
+	var zero IntList = nil
+	out := Reduce(a, rCons, zero).(IntList)
+	if !IntListEquals(out, list4321) {
+		t.Fatalf("expected [4,3,2,1] got something else")
 	}
 }


### PR DESCRIPTION
This patch generalizes reduce as it is in most programming languages.
1. It generalizes such that `zero` doesn't necessarily have to be an identity element for `pairFunction`. This allows one to add numbers in a slice with a non-zero initial value.
2. The return type and the type of `zero` is generalized such that they do not necessarily have to be the same as the element type. This allows one to implement the traditional list reversal example.

The generalizations have the side effect of making the code both shorter and, in my opinion, easier to understand.
