### PR TITLE
Didactically use generics to compare status post go 1.18

### DIFF
--- a/apply.go
+++ b/apply.go
@@ -16,36 +16,47 @@ import (
 	"reflect"
 )
 
-// Apply takes a slice of type []T and a function of type func(T) T. (If the
-// input conditions are not satisfied, Apply panics.) It returns a newly
-// allocated slice where each element is the result of calling the function on
-// successive elements of the slice.
-func Apply(slice, function interface{}) interface{} {
-	return apply(slice, function, false)
+// Apply takes a slice of type []T and a function of type func(T) T. It
+// returns a newly allocated slice where each element is the result of calling
+// the function on successive elements of the slice.
+func Apply[T any, U any](slice []T, function func(T) U) []U {
+	out := make([]U, len(slice), len(slice))
+	for i := 0; i < len(slice); i++ {
+		out[i] = function(slice[i])
+	}
+	return out
 }
 
 // ApplyInPlace is like Apply, but overwrites the slice rather than returning a
 // newly allocated slice.
-func ApplyInPlace(slice, function interface{}) {
-	apply(slice, function, true)
+func ApplyInPlace[T any](slice []T, function func(T) T) {
+	for i := 0; i < len(slice); i++ {
+		slice[i] = function(slice[i])
+	}
 }
 
-// Choose takes a slice of type []T and a function of type func(T) bool. (If
-// the input conditions are not satisfied, Choose panics.) It returns a newly
-// allocated slice containing only those elements of the input slice that
+// Choose takes a slice of type []T and a function of type func(T) bool. It
+// returns a newly allocated slice containing only those elements of the input
+// slice that satisfy the function.
+func Choose[T any](slice []T, function func(T) bool) []T {
+	return chooseOrDrop(slice, function, true)
+}
+
+// Drop takes a slice of type []T and a function of type func(T) bool. It
+// returns a newly allocated slice containing only those elements of the input
+// slice that do not satisfy the function, that is, it removes elements that
 // satisfy the function.
-func Choose(slice, function interface{}) interface{} {
-	out, _ := chooseOrDrop(slice, function, false, true)
-	return out
+func Drop[T any](slice []T, function func(T) bool) []T {
+	return chooseOrDrop(slice, function, false)
 }
 
-// Drop takes a slice of type []T and a function of type func(T) bool. (If the
-// input conditions are not satisfied, Drop panics.) It returns a newly
-// allocated slice containing only those elements of the input slice that do
-// not satisfy the function, that is, it removes elements that satisfy the
-// function.
-func Drop(slice, function interface{}) interface{} {
-	out, _ := chooseOrDrop(slice, function, false, false)
+func chooseOrDrop[T any](slice []T, function func(T) bool, truth bool) []T {
+	var out []T
+	for i := 0; i < len(slice); i++ {
+		if truth == function(slice[i]) {
+			out = append(out, slice[i])
+		}
+	}
 	return out
 }
 
@@ -53,7 +64,7 @@ func Drop(slice, function interface{}) interface{} {
 // a newly allocated slice. Since ChooseInPlace must modify the header of the
 // slice to set the new length, it takes as argument a pointer to a slice
 // rather than a slice.
-func ChooseInPlace(pointerToSlice, function interface{}) {
+func ChooseInPlace[T any](pointerToSlice *[]T, function func(T) bool) {
 	chooseOrDropInPlace(pointerToSlice, function, true)
 }
 
@@ -61,118 +72,17 @@ func ChooseInPlace(pointerToSlice, function interface{}) {
 // newly allocated slice. Since DropInPlace must modify the header of the slice
 // to set the new length, it takes as argument a pointer to a slice rather than
 // a slice.
-func DropInPlace(pointerToSlice, function interface{}) {
+func DropInPlace[T any](pointerToSlice *[]T, function func(T) bool) {
 	chooseOrDropInPlace(pointerToSlice, function, false)
 }
 
-func apply(slice, function interface{}, inPlace bool) interface{} {
-	// Special case for strings, very common.
-	if strSlice, ok := slice.([]string); ok {
-		if strFn, ok := function.(func(string) string); ok {
-			r := strSlice
-			if !inPlace {
-				r = make([]string, len(strSlice))
-			}
-			for i, s := range strSlice {
-				r[i] = strFn(s)
-			}
-			return r
+func chooseOrDropInPlace[T any](pointerToSlice *[]T, function func(T) bool, truth bool) {
+	n := 0
+	for i := 0; i < len(*pointerToSlice); i++ {
+		if truth == function((*pointerToSlice)[i]) {
+			(*pointerToSlice)[n] = (*pointerToSlice)[i]
+			n++
 		}
 	}
-	in := reflect.ValueOf(slice)
-	if in.Kind() != reflect.Slice {
-		panic("apply: not slice")
-	}
-	fn := reflect.ValueOf(function)
-	elemType := in.Type().Elem()
-	if !goodFunc(fn, elemType, nil) {
-		panic("apply: function must be of type func(" + in.Type().Elem().String() + ")  outputElemType")
-	}
-	out := in
-	if !inPlace {
-		out = reflect.MakeSlice(reflect.SliceOf(fn.Type().Out(0)), in.Len(), in.Len())
-	}
-	var ins [1]reflect.Value // Outside the loop to avoid one allocation.
-	for i := 0; i < in.Len(); i++ {
-		ins[0] = in.Index(i)
-		out.Index(i).Set(fn.Call(ins[:])[0])
-	}
-	return out.Interface()
-}
-
-func chooseOrDropInPlace(slice, function interface{}, truth bool) {
-	inp := reflect.ValueOf(slice)
-	if inp.Kind() != reflect.Ptr {
-		panic("choose/drop: not pointer to slice")
-	}
-	_, n := chooseOrDrop(inp.Elem().Interface(), function, true, truth)
-	inp.Elem().SetLen(n)
-}
-
-var boolType = reflect.ValueOf(true).Type()
-
-func chooseOrDrop(slice, function interface{}, inPlace, truth bool) (interface{}, int) {
-	// Special case for strings, very common.
-	if strSlice, ok := slice.([]string); ok {
-		if strFn, ok := function.(func(string) bool); ok {
-			var r []string
-			if inPlace {
-				r = strSlice[:0]
-			}
-			for _, s := range strSlice {
-				if strFn(s) == truth {
-					r = append(r, s)
-				}
-			}
-			return r, len(r)
-		}
-	}
-	in := reflect.ValueOf(slice)
-	if in.Kind() != reflect.Slice {
-		panic("choose/drop: not slice")
-	}
-	fn := reflect.ValueOf(function)
-	elemType := in.Type().Elem()
-	if !goodFunc(fn, elemType, boolType) {
-		panic("choose/drop: function must be of type func(" + elemType.String() + ") bool")
-	}
-	var which []int
-	var ins [1]reflect.Value // Outside the loop to avoid one allocation.
-	for i := 0; i < in.Len(); i++ {
-		ins[0] = in.Index(i)
-		if fn.Call(ins[:])[0].Bool() == truth {
-			which = append(which, i)
-		}
-	}
-	out := in
-	if !inPlace {
-		out = reflect.MakeSlice(in.Type(), len(which), len(which))
-	}
-	for i := range which {
-		out.Index(i).Set(in.Index(which[i]))
-	}
-	return out.Interface(), len(which)
-}
-
-// goodFunc verifies that the function satisfies the signature, represented as a slice of types.
-// The last type is the single result type; the others are the input types.
-// A final type of nil means any result type is accepted.
-func goodFunc(fn reflect.Value, types ...reflect.Type) bool {
-	if fn.Kind() != reflect.Func {
-		return false
-	}
-	// Last type is return, the rest are ins.
-	if fn.Type().NumIn() != len(types)-1 || fn.Type().NumOut() != 1 {
-		return false
-	}
-	for i := 0; i < len(types)-1; i++ {
-		if fn.Type().In(i) != types[i] {
-			return false
-		}
-	}
-	outType := types[len(types)-1]
-	if outType != nil && fn.Type().Out(0) != outType {
-		return false
-	}
-	return true
+	reflect.ValueOf(pointerToSlice).Elem().SetLen(n)
 }

--- a/apply_test.go
+++ b/apply_test.go
@@ -33,10 +33,6 @@ func isEvenString(a string) bool {
 	return a[0]%2 == 0
 }
 
-func is18(a int) bool {
-	return a == 18
-}
-
 func TestApply(t *testing.T) {
 	a := []int{1, 2, 3, 4, 5, 6, 7, 8, 9}
 	expect := []int{3, 6, 9, 12, 15, 18, 21, 24, 27}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module robpike.io/filter
 
-go 1.17
+go 1.18

--- a/reduce.go
+++ b/reduce.go
@@ -4,42 +4,27 @@
 
 package filter
 
-import (
-	"reflect"
-)
-
 // Reduce computes the reduction of the pair function across the elements of
-// the slice. (If the types of the slice and function do not correspond, Reduce
-// panics.) For instance, if the slice contains successive integers starting at
-// 1 and the function is multiply, the result will be the factorial function.
+// the slice. For instance, if the slice contains successive integers starting
+// at 1 and the function is multiply, the result will be the factorial function.
 // If the slice is empty, Reduce returns zero; if it has only one element, it
-// returns that element. The return value must be type-asserted by the caller
-// back to the element type of the slice. Example:
+// returns that element. Example:
+//
 //	func multiply(a, b int) int { return a*b }
 //	a := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 //	factorial := Reduce(a, multiply, 1).(int)
-func Reduce(slice, pairFunction, zero interface{}) interface{} {
-	in := reflect.ValueOf(slice)
-	if in.Kind() != reflect.Slice {
-		panic("reduce: not slice")
-	}
-	n := in.Len()
+func Reduce[T any](slice []T, pairFunction func(T, T) T, zero T) T {
+	n := len(slice)
 	if n == 0 {
 		return zero
 	}
-	elemType := in.Type().Elem()
-	fn := reflect.ValueOf(pairFunction)
-	if !goodFunc(fn, elemType, elemType, elemType) {
-		str := elemType.String()
-		panic("apply: function must be of type func(" + str + ", " + str + ") " + str)
+	if n == 1 {
+		return slice[0]
 	}
-	var ins [2]reflect.Value
-	out := in.Index(0) // By convention, fn(zero, in[0]) = in[0].
+	out := slice[0] // By convention, pairFunction(zero, slice[0]) = slice[0].
 	// Run from index 1 to the end.
 	for i := 1; i < n; i++ {
-		ins[0] = out
-		ins[1] = in.Index(i)
-		out = fn.Call(ins[:])[0]
+		out = pairFunction(out, slice[i])
 	}
-	return out.Interface()
+	return out
 }

--- a/reduce_test.go
+++ b/reduce_test.go
@@ -26,7 +26,7 @@ func TestReduce(t *testing.T) {
 		a[i] = i + 1
 	}
 	for i := 1; i < 10; i++ {
-		out := Reduce(a[:i], mul, 1).(int)
+		out := Reduce(a[:i], mul, 1)
 		expect := fac(i)
 		if expect != out {
 			t.Fatalf("expected %d got %d", expect, out)


### PR DESCRIPTION
Implementation is more straightforward.
Usability is (regrettably) somewhat improved.
Hopefully generification of source will not lead to gentrification of usage.

-----

The main purpose of this diff is just showing how much generics can simplify
implementation post go 1.18 while providing type safety.

Similar to the original repo - this is not to be used, rather pointed at. 